### PR TITLE
Bug item image

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -86,6 +86,9 @@ router.get("/", auth.optional, function(req, res, next) {
           items: await Promise.all(
             items.map(async function(item) {
               item.seller = await User.findById(item.seller);
+              if(!item.image){
+                item.image = "/placeholder.png";
+              }
               return item.toJSONFor(user);
             })
           ),
@@ -127,6 +130,9 @@ router.get("/feed", auth.required, function(req, res, next) {
 
         return res.json({
           items: items.map(function(item) {
+            if(!item.image){
+              item.image = "/placeholder.png";
+            }
             return item.toJSONFor(user);
           }),
           itemsCount: itemsCount
@@ -144,6 +150,9 @@ router.post("/", auth.required, function(req, res, next) {
       }
 
       var item = new Item(req.body.item);
+      if(!item.image){
+        item.image = "/placeholder.png";
+      } 
 
       item.seller = user;
 
@@ -164,6 +173,9 @@ router.get("/:item", auth.optional, function(req, res, next) {
     .then(function(results) {
       var user = results[0];
 
+      if(!results[1].image){
+        results[1].image = "/placeholder.png";
+      }
       return res.json({ item: req.item.toJSONFor(user) });
     })
     .catch(next);

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -44,7 +44,7 @@ const LoggedInView = (props) => {
         <li className="nav-item">
           <Link to={`/@${props.currentUser.username}`} className="nav-link">
             <img
-              src={props.currentUser.image}
+              src={props.currentUser.image|| '/placeholder.png'}
               className="user-pic pr-1"
               alt={props.currentUser.username}
             />

--- a/frontend/src/components/Item/CommentInput.js
+++ b/frontend/src/components/Item/CommentInput.js
@@ -42,7 +42,7 @@ class CommentInput extends React.Component {
         </div>
         <div className="card-footer">
           <img
-            src={this.props.currentUser.image}
+            src={this.props.currentUser.image || '/placeholder.png'}
             className="user-pic mr-2"
             alt={this.props.currentUser.username}
           />

--- a/frontend/src/components/Item/ItemMeta.js
+++ b/frontend/src/components/Item/ItemMeta.js
@@ -8,7 +8,7 @@ const ItemMeta = (props) => {
     <div className="d-flex flex-row align-items-center pt-2">
       <Link to={`/@${item.seller.username}`}>
         <img
-          src={item.seller.image}
+          src={item.seller.image || '/placeholder.png'}
           alt={item.seller.username}
           className="user-pic mr-2"
         />

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || '/placeholder.png'}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image || '/placeholder.png'}
+        src={item.image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || '/placeholder.png'}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />
@@ -49,7 +49,7 @@ const ItemPreview = (props) => {
         <div className="d-flex flex-row align-items-center pt-2">
           <Link to={`/@${item.seller.username}`} className="flex-grow-1">
             <img
-              src={item.seller.image}
+              src={item.seller.image || '/placeholder.png'}
               alt={item.seller.username}
               className="user-pic rounded-circle pr-1"
             />

--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -129,7 +129,7 @@ class Profile extends React.Component {
           <div className="row p-4 text-center">
             <div className="user-info col-xs-12 col-md-8 offset-md-2">
               <img
-                src={profile.image}
+                src={profile.image || '/placeholder.png'}
                 className="user-img"
                 alt={profile.username}
               />

--- a/frontend/src/reducers/editor.js
+++ b/frontend/src/reducers/editor.js
@@ -16,7 +16,7 @@ const reducer = (state = {}, action) => {
         itemSlug: action.payload ? action.payload.item.slug : "",
         title: action.payload ? action.payload.item.title : "",
         description: action.payload ? action.payload.item.description : "",
-        image: action.payload ? action.payload.item.image : "",
+        image: action.payload ? action.payload.item.image : '/placeholder.png',
         tagInput: "",
         tagList: action.payload ? action.payload.item.tagList : [],
       };

--- a/frontend/src/reducers/item.js
+++ b/frontend/src/reducers/item.js
@@ -10,7 +10,7 @@ const reducer = (state = {}, action) => {
     case ITEM_PAGE_LOADED:
       return {
         ...state,
-        item: action.payload[0].item,
+        item: { ...action.payload[0].item, image: action.payload[0].item.image || '/placeholder.png' },
         comments: action.payload[1].comments,
       };
     case ITEM_PAGE_UNLOADED:

--- a/frontend/src/reducers/itemList.js
+++ b/frontend/src/reducers/itemList.js
@@ -51,7 +51,7 @@ const reducer = (state = {}, action) => {
         ...state,
         pager: action.pager,
         tags: action.payload[0].tags,
-        items: action.payload[1].items,
+        items: action.payload[1].items.map(item => ({ ...item, image: item.image || '/placeholder.png' })),
         itemsCount: action.payload[1].itemsCount,
         currentPage: 0,
         tab: action.tab,

--- a/frontend/src/reducers/itemList.js
+++ b/frontend/src/reducers/itemList.js
@@ -73,7 +73,7 @@ const reducer = (state = {}, action) => {
       return {
         ...state,
         pager: action.pager,
-        items: action.payload[1].items,
+        items: action.payload[1].items.map(item => ({ ...item, image: item.image || '/placeholder.png' })),
         itemsCount: action.payload[1].itemsCount,
         currentPage: 0,
       };


### PR DESCRIPTION
# Description

Update `Itemslist` and `Item` reducers to use image place holder if no image from DB

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New feature
- [ ] A documentation update
- [ ] Refactoring

# How Has This Been Tested?

Reproduced by going to item page of an item without an image.
Tested by creating items without images and navigate between home-page and items pages.

**If this is a UI change / fix, please also add a screenshot**
![image](https://user-images.githubusercontent.com/48219965/150069795-3532dc34-d56b-4095-91ad-a4c64981063b.png)

![image](https://user-images.githubusercontent.com/48219965/150069820-41cad13a-66b5-43b8-9c1f-77a52dfd3e03.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I added the relevant people as reviewers to my PR
